### PR TITLE
Fix idmap leak in zygote process

### DIFF
--- a/libs/androidfw/AssetManager.cpp
+++ b/libs/androidfw/AssetManager.cpp
@@ -805,6 +805,7 @@ void AssetManager::addSystemOverlays(const char* pathOverlaysList,
             sharedRes->add(oass, oidmap, offset + 1, false);
             const_cast<AssetManager*>(this)->mAssetPaths.add(oap);
             const_cast<AssetManager*>(this)->mZipSet.addOverlay(targetPackagePath, oap);
+            delete oidmap;
         }
     }
     fclose(fin);


### PR DESCRIPTION
Fix a idmap leak in AssetManager::addSystemOverlays.
And, The fix could also prevent fd leak of idmap.

Test: none

Change-Id: Iff8831e1951a1ca103821f64a612a8b28d2c14e7
Signed-off-by: Hyangseok Chae <neo.chae@lge.com>