### PR TITLE
services: Doze only if GMS is installed

### DIFF
--- a/services/core/java/com/android/server/DeviceIdleController.java
+++ b/services/core/java/com/android/server/DeviceIdleController.java
@@ -84,6 +84,8 @@ import com.android.internal.util.FastXmlSerializer;
 import com.android.internal.util.XmlUtils;
 import com.android.server.am.BatteryStatsService;
 
+import org.cyanogenmod.internal.util.PackageManagerUtils;
+
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlSerializer;
@@ -1306,7 +1308,8 @@ public class DeviceIdleController extends SystemService
 
         synchronized (this) {
             mLightEnabled = mDeepEnabled = getContext().getResources().getBoolean(
-                    com.android.internal.R.bool.config_enableAutoPowerModes);
+                    com.android.internal.R.bool.config_enableAutoPowerModes) &&
+                    PackageManagerUtils.isAppInstalled(getContext(), "com.google.android.gms");
             SystemConfig sysConfig = SystemConfig.getInstance();
             ArraySet<String> allowPowerExceptIdle = sysConfig.getAllowInPowerSaveExceptIdle();
             for (int i=0; i<allowPowerExceptIdle.size(); i++) {

--- a/services/usage/Android.mk
+++ b/services/usage/Android.mk
@@ -9,4 +9,6 @@ LOCAL_SRC_FILES += \
 
 LOCAL_JAVA_LIBRARIES := services.core
 
+LOCAL_JAVA_LIBRARIES += org.cyanogenmod.platform.internal
+
 include $(BUILD_STATIC_JAVA_LIBRARY)

--- a/services/usage/java/com/android/server/usage/UsageStatsService.java
+++ b/services/usage/java/com/android/server/usage/UsageStatsService.java
@@ -78,6 +78,8 @@ import com.android.internal.util.ArrayUtils;
 import com.android.internal.util.IndentingPrintWriter;
 import com.android.server.SystemService;
 
+import org.cyanogenmod.internal.util.PackageManagerUtils;
+
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -189,7 +191,8 @@ public class UsageStatsService extends SystemService implements
                 null, mHandler);
 
         mAppIdleEnabled = getContext().getResources().getBoolean(
-                com.android.internal.R.bool.config_enableAutoPowerModes);
+                com.android.internal.R.bool.config_enableAutoPowerModes) &&
+                PackageManagerUtils.isAppInstalled(getContext(), "com.google.android.gms");
         if (mAppIdleEnabled) {
             IntentFilter deviceStates = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
             deviceStates.addAction(BatteryManager.ACTION_DISCHARGING);


### PR DESCRIPTION
According to the Android docs, doze is only supported
when the device has a cloud messaging service.
In our case, it is Google Cloud Messaging, which is
package within Google Mobile Services.

Hence, only doze when GMS is available on the device.

Change-Id: I8e7d5558da11ec172c206aa356505b7526f39a3f