### PR TITLE
[1/2] base: support separate encryption/lockscreen passwords

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5117,6 +5117,14 @@ public final class Settings {
         public static final String LOCK_SCREEN_ALLOW_PRIVATE_NOTIFICATIONS =
                 "lock_screen_allow_private_notifications";
 
+
+        /**
+         * Separate password for encryption and the lockscreen.
+          * @hide
+         */
+        public static final String LOCK_SEPARATE_ENCRYPTION_PASSWORD =
+                "lock_separate_encryption_password";
+
         /**
          * When set by a user, allows notification remote input atop a securely locked screen
          * without having to unlock

--- a/services/core/java/com/android/server/LockSettingsService.java
+++ b/services/core/java/com/android/server/LockSettingsService.java
@@ -1638,6 +1638,7 @@ public class LockSettingsService extends ILockSettings.Stub {
         Secure.LOCK_BIOMETRIC_WEAK_FLAGS,
         Secure.LOCK_PATTERN_VISIBLE,
         Secure.LOCK_PATTERN_TACTILE_FEEDBACK_ENABLED,
+        Secure.LOCK_SEPARATE_ENCRYPTION_PASSWORD,
         Secure.LOCK_PATTERN_SIZE,
         Secure.LOCK_DOTS_VISIBLE,
         Secure.LOCK_SHOW_ERROR_PATH,


### PR DESCRIPTION
This adds the necessary infrastructure for allowing users to opt-in to a
distinct device encryption passphrase. The passwords are still tied
together by default. This makes it possible to use a complex encryption
passphrase without losing the convenience of a very simple lockscreen
pin.

This feature can be combined with a forced reboot after a chosen number
of failed unlocking attempts to prevent brute-forcing by requiring the
entry of the encryption password instead.

Change-Id: Iaf89af9bfa7e07f325eec7a60fdcc4de5977055a